### PR TITLE
add namespace and support non sdk input

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -15,7 +15,7 @@ log = logging.getLogger()
 log.setLevel(logging.INFO)
 if len(sys.argv) < 2:
     log.error("namespace argument required")
-    os.Exit(1)
+    sys.exit(1)
 namespace = sys.argv[1]
 backup = dr.Backup(loglevel="DEBUG", bucket_name='bank-app-backup')
 backup.save_namespace(namespace)


### PR DESCRIPTION
Added code to create a namespace yaml, so namespace can be created in target
This is named <cluster>/<namespace>/Namespace/<version>/<namespace>
i.e. cluster1/default/Namespace/v1/default

Also fix the functions that process the object returned by sdk so they work on a normal dictionary too
This means they can be used by the admission controller webhook which has a json payload that is converted to a dictionary.